### PR TITLE
net/l2: openthread: Add support for retrying automatic joiner start

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -156,6 +156,12 @@ config OPENTHREAD_JOINER_AUTOSTART
 	help
 	  Enable automatic joiner start
 
+config OPENTHREAD_JOINER_AUTOSTART_RETRY
+	bool "Retry automatic joiner start"
+	depends on OPENTHREAD_JOINER_AUTOSTART
+	help
+	  Enable retrying automatic joiner start
+
 config OPENTHREAD_JOINER_PSKD
 	string "Default Pre Shared key for the Device to start joiner"
 	depends on OPENTHREAD_JOINER_AUTOSTART

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -188,6 +188,10 @@ void ot_joiner_start_handler(otError error, void *context)
 		break;
 	default:
 		NET_ERR("Join failed [%d]", error);
+#if defined(CONFIG_OPENTHREAD_JOINER_AUTOSTART_RETRY)
+		openthread_joiner_autostart(ot_context->iface);
+		NET_ERR("Retrying to join...");
+#endif
 		break;
 	}
 }


### PR DESCRIPTION
This commit enables retrying start joiner if it failed.

Signed-off-by: Takumi Ando <takumi.ando@atmark-techno.com>