### PR TITLE
kernel: timeout: do not active time slicing if idle thread ready

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -297,6 +297,8 @@ void z_time_slice(int ticks)
 		} else {
 			_current_cpu->slice_ticks -= ticks;
 		}
+	} else {
+		_current_cpu->slice_ticks = 0;
 	}
 }
 #else


### PR DESCRIPTION
zero slice_ticks when can't time slice so that next_timeout will
ignore slice_ticks of _current_cpu and system can stay low power
state longer time.

Fixes: #17368.

Signed-off-by: Wentong Wu <wentong.wu@intel.com>