### PR TITLE
subsys/fs/fatfs: Add kconfig option for FAT LFN (Long Filename)

### DIFF
--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -70,6 +70,76 @@ config FS_FATFS_NUM_FILES
 config FS_FATFS_NUM_DIRS
 	int "Maximum number of opened directories"
 	default 4
+
+config FS_FATFS_LFN
+	bool "Enable long filenames (LFN)"
+	help
+	  Without long filenames enabled, file names are limited to 8.3 format.
+	  This option increases working buffer size.
+
+if FS_FATFS_LFN
+
+choice
+	prompt "LFN memory mode"
+	default FS_FATFS_LFN_MODE_BSS
+
+config FS_FATFS_LFN_MODE_BSS
+	bool "Static buffer"
+	help
+	  Enable LFN with static working buffer on the BSS. Always NOT thread-safe.
+
+config FS_FATFS_LFN_MODE_STACK
+	bool "Stack buffer"
+	help
+	  Enable LFN with dynamic working buffer on the STACK.
+
+config FS_FATFS_LFN_MODE_HEAP
+	bool "Heap buffer"
+	help
+	  Enable LFN with dynamic working buffer on the HEAP.
+
+endchoice
+
+config FS_FATFS_MAX_LFN
+	int "Max filename length"
+	range 12 255
+	default 255
+	help
+	  The working buffer occupies (FS_FATFS_MAX_LFN + 1) * 2 bytes and
+	  additional 608 bytes at exFAT enabled.
+	  It should be set 255 to support full featured LFN operations.
+
+endif # FS_FATFS_LFN
+
+config FS_FATFS_CODEPAGE
+	int "FatFS code page (character set)"
+	default 437 if FS_FATFS_LFN
+	default 1
+	help
+	  Valid code page values:
+	  1   - ASCII (No extended character. Non-LFN cfg. only)
+	  437 - U.S.
+	  720 - Arabic
+	  737 - Greek
+	  771 - KBL
+	  775 - Baltic
+	  850 - Latin 1
+	  852 - Latin 2
+	  855 - Cyrillic
+	  857 - Turkish
+	  860 - Portuguese
+	  861 - Icelandic
+	  862 - Hebrew
+	  863 - Canadian French
+	  864 - Arabic
+	  865 - Nordic
+	  866 - Russian
+	  869 - Greek 2
+	  932 - Japanese (DBCS)
+	  936 - Simplified Chinese (DBCS)
+	  949 - Korean (DBCS)
+	  950 - Traditional Chinese (DBCS)
+
 endmenu
 
 menu "NFFS Settings"

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
       revision: 6835bfc741bf15e98fb7971293913f770df6081f
       path: modules/hal/esp-idf
     - name: fatfs
-      revision: df96914dd989907f3a5de4cb95b116c2f305820d
+      revision: 9ee6b9b9511151d0d64a74d532d39c6f2bbd4f16
       path: modules/fs/fatfs
     - name: hal_qmsi
       revision: 9195fe6f97e4f7f25a3fc9e5a515f1b7af13762c


### PR DESCRIPTION
ELM FatFS implementation supports LFN, enabled via ffconf.h
configuration file. Additionally, code page (character set),
max file name length, and memory mode (LFN working buffer location)
are configurable options closely related to LFN.
Without LFN filenames are restricted to 8.3 filename format.

Add kconfig options to expose following FatFS configurations:
enable LFN, specify max filename length, specify code page
(character set), specify LFN working buffer location.

Signed-off-by: Audun Korneliussen <audun.korneliussen@nordicsemi.no>